### PR TITLE
Split the run function to allow calling from Python

### DIFF
--- a/iqmma/cli.py
+++ b/iqmma/cli.py
@@ -1,0 +1,152 @@
+import argparse
+import sys
+import os
+import logging
+from . import utils, iqmma
+
+def run():
+    parser = argparse.ArgumentParser(
+        description = 'Proteomics quantitation workflow',
+        epilog = '''
+    Example of usage
+    -------------
+    (prefered way)
+    Basic command for quantitation mode:
+
+    $ iqmma -bio2 path_to_Biosaur2
+            -dino path_to_Dinosaur
+            -openms path_to_openMS
+            -dif path_to_Diffacto
+            -s1 paths_to_mzml_files_from_sample_1_*.mzML
+            -s2 paths_to_mzml_files_from_sample_2_*.mzML
+
+    Basic command for matching peptide intensities: (all mzml files goes into first sample without any differences, no quantitation applied)
+
+    $ iqmma -bio2 path_to_Biosaur2
+            -dino path_to_Dinosaur
+            -openms path_to_openMS
+            -dif path_to_Diffacto -s1 paths_to_all_mzml_files_*.mzML -outdir out_path
+
+    Or both mods could be used with config file for an advanced usage and configuration:
+
+    $ iqmma -cfg path_to_config_file -cfg_category name_of_category_in_cfg
+
+    -------------
+    ''',
+        formatter_class = argparse.ArgumentDefaultsHelpFormatter, fromfile_prefix_chars='@')
+
+    parser.add_argument('-logs', nargs='?', help='level of logging, (DEBUG, INFO, WARNING, ERROR, CRITICAL)', type=str, default='INFO', const='INFO', choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL', 'NOTSET', 'debug', 'info', 'warning', 'error', 'critical', 'nonset'])
+    parser.add_argument('-log_path', nargs='?', help='path to logging file', type=str, default='./iqmma.log', const='./iqmma.log')
+    parser.add_argument('-cfg', nargs='?', help='path to config .ini file', type=str, default='', const='')
+    parser.add_argument('-cfg_category', nargs='?', help='name of category to prioritize in the .ini file, default: DEFAULT', type=str, default='DEFAULT', const='DEFAULT')
+    parser.add_argument('-example_cfg', nargs='?', help='Path to create example config .ini file or not if not stated', type=str, default='', const='')
+    parser.add_argument('-dif', nargs='?', help='path to Diffacto', type=str, default='', const='')
+#    parser.add_argument('-scav2dif', help='path to scav2diffacto')
+    parser.add_argument('-s1', nargs='*', help='input mzML files for sample 1 (also file names are the keys for searching other needed files)', type=str, default='', )
+    parser.add_argument('-s2', nargs='*', help='input mzML files for sample 2 (also file names are the keys for searching other needed files)', type=str, default='', )
+#    parser.add_argument('-sampleNames', nargs='+', help='short names for samples for inner structure of results')
+    parser.add_argument('-psm_folder', nargs='?', help='path to the folder with PSMs files', type=str, default='', const='')
+    parser.add_argument('-psm_format', nargs='?', help='format or suffix to search PSMs files (may be PSMs_full.tsv or identipy.pep.xml for example)', type=str, default='PSMs_full.tsv', const='PSMs_full.tsv')
+    parser.add_argument('-allowed_pepts', nargs='?', help='path to file with sequences of peptides (with "peptide" header) to use in quantitation', type=str, default='', const='')
+    parser.add_argument('-allowed_prots', nargs='?', help='path to file with names of proteins (according fasta, with "dbname" header) to use in quantitation', type=str, default='', const='')
+
+    parser.add_argument('-dino', nargs='?', help='path to Dinosaur', type=str, default='', const='')
+#    parser.add_argument('-bio', nargs='?', help='path to Biosaur', type=str, default='', const='')
+    parser.add_argument('-bio2', nargs='?', help='path to Biosaur2', type=str, default='', const='')
+    parser.add_argument('-openMS', nargs='?', help='path to OpenMS FeatureFinderCentroided', type=str, default='', const='')
+
+    parser.add_argument('-outdir', nargs='?', help='name of directory to store results', type=str, default='', const='')
+    parser.add_argument('-feature_folder', nargs='?', help='directory to store features', type=str, default='', const='')
+    parser.add_argument('-matching_folder', nargs='?', help='directory to store matched psm-feature pairs', type=str, default='', const='')
+    parser.add_argument('-diffacto_folder', nargs='?', help='directory to store diffacto results', type=str, default='', const='')
+
+    parser.add_argument('-overwrite_features', nargs='?', help='whether to overwrite existed features files (flag == 1) or use them (flag == 0)', type=int, default=0, const=0, choices=[0, 1])
+    parser.add_argument('-overwrite_matching', nargs='?', help='whether to overwrite existed matched files (flag == 1) or use them (flag == 0)', type=int, default=0, const=0, choices=[0, 1])
+    parser.add_argument('-overwrite_first_diffacto', nargs='?', help='whether to overwrite existed diffacto files (flag == 1) or use them (flag == 0)', type=int, default=1, const=1, choices=[0, 1])
+    parser.add_argument('-mixed', nargs='?', help='whether to reanalyze mixed intensities (1) or not (0)', type=int, default=1, const=1, choices=[0, 1])
+    parser.add_argument('-venn', nargs='?', help='whether to plot venn diagrams (1) or not (0)', type=int, default=1, const=1, choices=[0, 1])
+    parser.add_argument('-pept_intens', nargs='?', help='max_intens - as intensity for peptide would be taken maximal intens between charge states; summ_intens - as intensity for peptide would be taken sum of intens between charge states; z-attached - each charge state would be treated as independent peptide', type=str, default='z-attached', const='z-attached', choices=['z-attached', 'summ_intens', 'max_intens'])
+    parser.add_argument('-choice', nargs='?', help='method how to choose right intensities for peptide. 0 - default order and min Nan values, 1 - min Nan and min of sum CV, 2 - min Nan and min of max CV, 3 - min Nan and min of squared sum CV, 4 - min Nan and min of squared sum of corrected CV', type=int, default=4, const=4, choices=[0, 1, 2, 3, 4,])
+    parser.add_argument('-norm', nargs='?', help='normalization method for intensities to remove biases between feature detections. Applied for each file independently. Can be 3 - max, 2 - min, 1 - median or 0 - no normalization. 2 and 3 options are strongly not recommended to use.', type=int, default=1, const=1, choices=[0, 1, 2, 3])
+    parser.add_argument('-isotopes', help='monoisotope error', nargs='+', type=int, default=[0,1,-1,2,-2])
+    parser.add_argument('-outpept', nargs='?', help='name of output diffacto peptides file (important: .txt)', type=str, default='peptides.txt', const='peptides.txt')
+    parser.add_argument('-outsampl', nargs='?', help='name of output diffacto samples file (important: .txt)', type=str, default='sample.txt', const='sample.txt')
+    parser.add_argument('-outdiff', nargs='?', help='name of diffacto output file (important: .txt)', type=str, default='diffacto_out.txt', const='diffacto_out.txt')
+    parser.add_argument('-min_samples', nargs='?', help='minimum number of samples for peptide usage, 0 means that the minimum of the number of files in s1 and s2 would be used, -1 means that half of the given number of files would be used', type=int, default=0, const=0)
+
+    parser.add_argument('-mbr', nargs='?', help='match between runs (1 - on, 0 - off)', type=int, default=0, const=0, choices=[0, 1])
+    parser.add_argument('-pval_threshold', nargs='?', help='P-value threshold for reliable differetially expressed proteins', type=float, default=0.05, const=0.05)
+    parser.add_argument('-fc_threshold', nargs='?', help='Fold change threshold for reliable differetially expressed proteins', type=float, default=1., const=1.)
+    parser.add_argument('-dynamic_fc_threshold', nargs='?', help='whether to apply dynamically calculated threshold (1) or not and use static -fc_threshold (0) ', type=int, default=1, const=1, choices=[0, 1])
+    parser.add_argument('-pval_adj', nargs='?', help='P value adjustment method for multiple comparisons: Bonf - Bonferroni correction, BH - Benjamini–Hochberg procedure.', type=str, default='Bonf', const='Bonf', choices=['Bonf', 'BH'])
+
+    parser.add_argument('-diffacto_args', nargs='?', help='String of additional arguments to submit into Diffacto (in command line the string should be in double quotes: \'\" \"\', in cfg file in single quotes) except: -i, -out, -samples, -min_samples; default: "-normalize median -impute_threshold 0.99" ', type=str, default='-normalize median -impute_threshold 0.99', const='')
+    parser.add_argument('-dino_args', nargs='?', help='String of additional arguments to submit into Dinosaur (in command line the string should be in double quotes: \'\" \"\', in cfg file in single quotes) except: --outDir --outName; default: ""', type=str, default='', const='')
+#    parser.add_argument('-bio_args', nargs='?', help='String of additional arguments to submit into Biosaur (hole string in single quotes in command line) except: -o; default: ""', type=str, default='', const='')
+    parser.add_argument('-bio2_args', nargs='?', help='String of additional arguments to submit into Biosaur2 (in command line the string should be in double quotes: \'\" \"\', in cfg file in single quotes) except: -o; default: "-hvf 1000 -minlh 3"', type=str, default='-hvf 1000 -minlh 3', const='')
+    parser.add_argument('-openms_args', nargs='?', help='String of additional arguments to submit into OpenMSFeatureFinder (in command line the string should be in double quotes: \'\" \"\', in cfg file in single quotes) except: -in, -out; default: "-algorithm:isotopic_pattern:charge_low 2 -algorithm:isotopic_pattern:charge_high 7"', type=str, default='-algorithm:isotopic_pattern:charge_low 2 -algorithm:isotopic_pattern:charge_high 7', const='')
+    parser.add_argument('-decoy_prefix', nargs='?', help='String added to the protein name to showcase that it is a decoy (default: DECOY)', type=str, default='DECOY', const='DECOY')
+    parser.add_argument('-threads', nargs='?', help='Number of threads for multiprocessing for Biosaur2 and FeatureFinderCentroided feature detections, recommended value is a number of the processor cores. Not overwrites individual values stated via -programm_args options.', type=int, default=4, const=4)
+
+#    parser.add_argument('-version', action='version', version='%s' % (pkg_resources.require("scavager")[0], ))
+    console_config = vars(parser.parse_args())
+    console_keys = [x[1:] for x in sys.argv if x.startswith('-')]
+    default_config = vars(parser.parse_args([]))
+    users_config = {}
+    if console_config['cfg'] :
+        if os.path.exists(console_config['cfg']) :
+            if console_config['cfg_category'] :
+                s, users_keys = utils.read_cfg(console_config['cfg'] , console_config['cfg_category'] )
+            else :
+                s, users_keys = utils.read_cfg( console_config['cfg'], default_config['cfg_category'] )
+            users_config = vars(parser.parse_args(s))
+        else :
+            logging.critical('path to config file does not exist')
+            return -1
+
+    args = default_config
+    if users_config :
+        for k in users_keys :
+            args.update({k: users_config[k]})
+    for k in console_keys :
+        args.update({k: console_config[k]})
+
+    loglevel = args['logs'].upper()
+    numeric_level = getattr(logging, loglevel, None)
+    if not isinstance(numeric_level, int):
+        raise ValueError('Invalid log level: %s' % loglevel)
+
+    logger = logging.getLogger('logger')
+    logger.setLevel(loglevel)
+    formatter = logging.Formatter('%(asctime)s [%(levelname)s]: %(message)s')
+    ch = logging.StreamHandler(sys.stdout)
+    ch.setLevel(loglevel)
+    ch.setFormatter(formatter)
+    logger.addHandler(ch)
+
+    if args['log_path'] :
+        args['log_path'] = os.path.abspath(os.path.normpath(args['log_path']))
+        log_directory = os.path.dirname(args['log_path'])
+        os.makedirs(log_directory, exist_ok=True)
+        fh = logging.FileHandler(args['log_path'], mode='w', encoding='utf-8')
+        fh.setLevel(loglevel)
+        fh.setFormatter(formatter)
+        logger.addHandler(fh)
+
+    logging.getLogger('matplotlib').setLevel(logging.ERROR)
+
+    logger.info('Started')
+
+    if args['example_cfg'] :
+        p = os.path.abspath(os.path.normpath(args['example_cfg']))
+        if os.path.exists(os.path.dirname(p)) or os.path.exists(p) :
+            if os.path.exists(p) :
+                logger.info('Example cfg would be overwrited')
+            utils.write_example_cfg(args['example_cfg'], default_config)
+            logger.info('Example cfg created')
+            return 0
+        else :
+            logger.warning('Invalid path for example cfg creation. Directory does not exist')
+            return 1
+
+    iqmma.process_files(args)

--- a/iqmma/iqmma.py
+++ b/iqmma/iqmma.py
@@ -1,20 +1,11 @@
-import argparse
-import subprocess
-import sys
-import configparser
 import pandas as pd
-import numpy as np
 from pyteomics.openms import featurexml
-import copy
 import os
 import errno
-import time
-import ast
 import re
-from os import listdir
 import logging
 
-from .utils import read_cfg, write_example_cfg, call_Dinosaur, call_Biosaur2, call_OpenMS, gaus, noisygaus, opt_bin, generate_users_output, diffacto_call, mix_intensity, charge_states_intensity_processing, read_PSMs, calibrate_mass, total, found_mean_sigma, optimized_search_with_isotope_error_, mbr
+from .utils import call_Dinosaur, call_Biosaur2, call_OpenMS, generate_users_output, diffacto_call, mix_intensity, charge_states_intensity_processing, read_PSMs, optimized_search_with_isotope_error_, mbr
 
 
 class WrongInputError(NotImplementedError):
@@ -25,151 +16,11 @@ class EmptyFileError(ValueError):
     pass
 
 
-def run():
-    parser = argparse.ArgumentParser(
-        description = 'Proteomics quantitation workflow',
-        epilog = '''
-    Example of usage
-    -------------
-    (prefered way)
-    Basic command for quantitation mode:
+logger = logging.getLogger(__name__)
 
-    $ iqmma -bio2 path_to_Biosaur2 
-            -dino path_to_Dinosaur 
-            -openms path_to_openMS 
-            -dif path_to_Diffacto 
-            -s1 paths_to_mzml_files_from_sample_1_*.mzML 
-            -s2 paths_to_mzml_files_from_sample_2_*.mzML
 
-    Basic command for matching peptide intensities: (all mzml files goes into first sample without any differences, no quantitation applied)
+def process_files(args):
 
-    $ iqmma -bio2 path_to_Biosaur2 
-            -dino path_to_Dinosaur 
-            -openms path_to_openMS 
-            -dif path_to_Diffacto -s1 paths_to_all_mzml_files_*.mzML -outdir out_path
-    
-    Or both mods could be used with config file for an advanced usage and configuration:
-
-    $ iqmma -cfg path_to_config_file -cfg_category name_of_category_in_cfg
-                                          
-    -------------
-    ''',
-        formatter_class = argparse.ArgumentDefaultsHelpFormatter, fromfile_prefix_chars='@')
-    
-    parser.add_argument('-logs', nargs='?', help='level of logging, (DEBUG, INFO, WARNING, ERROR, CRITICAL)', type=str, default='INFO', const='INFO', choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL', 'NOTSET', 'debug', 'info', 'warning', 'error', 'critical', 'nonset'])
-    parser.add_argument('-log_path', nargs='?', help='path to logging file', type=str, default='./iqmma.log', const='./iqmma.log')
-    parser.add_argument('-cfg', nargs='?', help='path to config .ini file', type=str, default='', const='')
-    parser.add_argument('-cfg_category', nargs='?', help='name of category to prioritize in the .ini file, default: DEFAULT', type=str, default='DEFAULT', const='DEFAULT')
-    parser.add_argument('-example_cfg', nargs='?', help='Path to create example config .ini file or not if not stated', type=str, default='', const='')
-    parser.add_argument('-dif', nargs='?', help='path to Diffacto', type=str, default='', const='')
-#    parser.add_argument('-scav2dif', help='path to scav2diffacto')
-    parser.add_argument('-s1', nargs='*', help='input mzML files for sample 1 (also file names are the keys for searching other needed files)', type=str, default='', )
-    parser.add_argument('-s2', nargs='*', help='input mzML files for sample 2 (also file names are the keys for searching other needed files)', type=str, default='', )
-#    parser.add_argument('-sampleNames', nargs='+', help='short names for samples for inner structure of results')
-    parser.add_argument('-psm_folder', nargs='?', help='path to the folder with PSMs files', type=str, default='', const='')
-    parser.add_argument('-psm_format', nargs='?', help='format or suffix to search PSMs files (may be PSMs_full.tsv or identipy.pep.xml for example)', type=str, default='PSMs_full.tsv', const='PSMs_full.tsv')
-    parser.add_argument('-allowed_pepts', nargs='?', help='path to file with sequences of peptides (with "peptide" header) to use in quantitation', type=str, default='', const='')
-    parser.add_argument('-allowed_prots', nargs='?', help='path to file with names of proteins (according fasta, with "dbname" header) to use in quantitation', type=str, default='', const='')
-    
-    parser.add_argument('-dino', nargs='?', help='path to Dinosaur', type=str, default='', const='')
-#    parser.add_argument('-bio', nargs='?', help='path to Biosaur', type=str, default='', const='')
-    parser.add_argument('-bio2', nargs='?', help='path to Biosaur2', type=str, default='', const='')
-    parser.add_argument('-openMS', nargs='?', help='path to OpenMS FeatureFinderCentroided', type=str, default='', const='')
-    
-    parser.add_argument('-outdir', nargs='?', help='name of directory to store results', type=str, default='', const='')
-    parser.add_argument('-feature_folder', nargs='?', help='directory to store features', type=str, default='', const='')
-    parser.add_argument('-matching_folder', nargs='?', help='directory to store matched psm-feature pairs', type=str, default='', const='')
-    parser.add_argument('-diffacto_folder', nargs='?', help='directory to store diffacto results', type=str, default='', const='')
-    
-    parser.add_argument('-overwrite_features', nargs='?', help='whether to overwrite existed features files (flag == 1) or use them (flag == 0)', type=int, default=0, const=0, choices=[0, 1])
-    parser.add_argument('-overwrite_matching', nargs='?', help='whether to overwrite existed matched files (flag == 1) or use them (flag == 0)', type=int, default=0, const=0, choices=[0, 1])
-    parser.add_argument('-overwrite_first_diffacto', nargs='?', help='whether to overwrite existed diffacto files (flag == 1) or use them (flag == 0)', type=int, default=1, const=1, choices=[0, 1])
-    parser.add_argument('-mixed', nargs='?', help='whether to reanalyze mixed intensities (1) or not (0)', type=int, default=1, const=1, choices=[0, 1])
-    parser.add_argument('-venn', nargs='?', help='whether to plot venn diagrams (1) or not (0)', type=int, default=1, const=1, choices=[0, 1])
-    parser.add_argument('-pept_intens', nargs='?', help='max_intens - as intensity for peptide would be taken maximal intens between charge states; summ_intens - as intensity for peptide would be taken sum of intens between charge states; z-attached - each charge state would be treated as independent peptide', type=str, default='z-attached', const='z-attached', choices=['z-attached', 'summ_intens', 'max_intens'])
-    parser.add_argument('-choice', nargs='?', help='method how to choose right intensities for peptide. 0 - default order and min Nan values, 1 - min Nan and min of sum CV, 2 - min Nan and min of max CV, 3 - min Nan and min of squared sum CV, 4 - min Nan and min of squared sum of corrected CV', type=int, default=4, const=4, choices=[0, 1, 2, 3, 4,])
-    parser.add_argument('-norm', nargs='?', help='normalization method for intensities to remove biases between feature detections. Applied for each file independently. Can be 3 - max, 2 - min, 1 - median or 0 - no normalization. 2 and 3 options are strongly not recommended to use.', type=int, default=1, const=1, choices=[0, 1, 2, 3])
-    parser.add_argument('-isotopes', help='monoisotope error', nargs='+', type=int, default=[0,1,-1,2,-2])
-    parser.add_argument('-outpept', nargs='?', help='name of output diffacto peptides file (important: .txt)', type=str, default='peptides.txt', const='peptides.txt')
-    parser.add_argument('-outsampl', nargs='?', help='name of output diffacto samples file (important: .txt)', type=str, default='sample.txt', const='sample.txt')
-    parser.add_argument('-outdiff', nargs='?', help='name of diffacto output file (important: .txt)', type=str, default='diffacto_out.txt', const='diffacto_out.txt')
-    parser.add_argument('-min_samples', nargs='?', help='minimum number of samples for peptide usage, 0 means that the minimum of the number of files in s1 and s2 would be used, -1 means that half of the given number of files would be used', type=int, default=0, const=0)
-    
-    parser.add_argument('-mbr', nargs='?', help='match between runs (1 - on, 0 - off)', type=int, default=0, const=0, choices=[0, 1])
-    parser.add_argument('-pval_threshold', nargs='?', help='P-value threshold for reliable differetially expressed proteins', type=float, default=0.05, const=0.05)
-    parser.add_argument('-fc_threshold', nargs='?', help='Fold change threshold for reliable differetially expressed proteins', type=float, default=1., const=1.)
-    parser.add_argument('-dynamic_fc_threshold', nargs='?', help='whether to apply dynamically calculated threshold (1) or not and use static -fc_threshold (0) ', type=int, default=1, const=1, choices=[0, 1])
-    parser.add_argument('-pval_adj', nargs='?', help='P value adjustment method for multiple comparisons: Bonf - Bonferroni correction, BH - Benjamini–Hochberg procedure.', type=str, default='Bonf', const='Bonf', choices=['Bonf', 'BH'])
-
-    parser.add_argument('-diffacto_args', nargs='?', help='String of additional arguments to submit into Diffacto (in command line the string should be in double quotes: \'\" \"\', in cfg file in single quotes) except: -i, -out, -samples, -min_samples; default: "-normalize median -impute_threshold 0.99" ', type=str, default='-normalize median -impute_threshold 0.99', const='')
-    parser.add_argument('-dino_args', nargs='?', help='String of additional arguments to submit into Dinosaur (in command line the string should be in double quotes: \'\" \"\', in cfg file in single quotes) except: --outDir --outName; default: ""', type=str, default='', const='')
-#    parser.add_argument('-bio_args', nargs='?', help='String of additional arguments to submit into Biosaur (hole string in single quotes in command line) except: -o; default: ""', type=str, default='', const='')
-    parser.add_argument('-bio2_args', nargs='?', help='String of additional arguments to submit into Biosaur2 (in command line the string should be in double quotes: \'\" \"\', in cfg file in single quotes) except: -o; default: "-hvf 1000 -minlh 3"', type=str, default='-hvf 1000 -minlh 3', const='')
-    parser.add_argument('-openms_args', nargs='?', help='String of additional arguments to submit into OpenMSFeatureFinder (in command line the string should be in double quotes: \'\" \"\', in cfg file in single quotes) except: -in, -out; default: "-algorithm:isotopic_pattern:charge_low 2 -algorithm:isotopic_pattern:charge_high 7"', type=str, default='-algorithm:isotopic_pattern:charge_low 2 -algorithm:isotopic_pattern:charge_high 7', const='')
-    parser.add_argument('-decoy_prefix', nargs='?', help='String added to the protein name to showcase that it is a decoy (default: DECOY)', type=str, default='DECOY', const='DECOY')
-    parser.add_argument('-threads', nargs='?', help='Number of threads for multiprocessing for Biosaur2 and FeatureFinderCentroided feature detections, recommended value is a number of the processor cores. Not overwrites individual values stated via -programm_args options.', type=int, default=4, const=4)
-    
-#    parser.add_argument('-version', action='version', version='%s' % (pkg_resources.require("scavager")[0], ))
-    console_config = vars(parser.parse_args())
-    console_keys = [x[1:] for x in sys.argv if x.startswith('-')]
-    default_config = vars(parser.parse_args([]))
-    users_config = {}
-    if console_config['cfg'] :
-        if os.path.exists(console_config['cfg']) :
-            if console_config['cfg_category'] :
-                s, users_keys = read_cfg(console_config['cfg'] , console_config['cfg_category'] )
-            else :
-                s, users_keys = read_cfg( console_config['cfg'], default_config['cfg_category'] )
-            users_config = vars(parser.parse_args(s))
-        else :
-            logging.critical('path to config file does not exist')
-            return -1
-    
-    args = default_config
-    if users_config :
-        for k in users_keys :
-            args.update({k: users_config[k]})
-    for k in console_keys :
-        args.update({k: console_config[k]})
-    
-    loglevel = args['logs'].upper()
-    numeric_level = getattr(logging, loglevel, None)
-    if not isinstance(numeric_level, int):
-        raise ValueError('Invalid log level: %s' % loglevel)
-
-    logger = logging.getLogger('logger')
-    logger.setLevel(loglevel)
-    formatter = logging.Formatter('%(asctime)s [%(levelname)s]: %(message)s')
-    ch = logging.StreamHandler(sys.stdout)
-    ch.setLevel(loglevel)
-    ch.setFormatter(formatter)
-    logger.addHandler(ch)
-
-    if args['log_path'] :
-        args['log_path'] = os.path.abspath(os.path.normpath(args['log_path']))
-        log_directory = os.path.dirname(args['log_path'])
-        os.makedirs(log_directory, exist_ok=True)
-        fh = logging.FileHandler(args['log_path'], mode='w', encoding='utf-8')
-        fh.setLevel(loglevel)
-        fh.setFormatter(formatter)
-        logger.addHandler(fh)
-
-    logging.getLogger('matplotlib').setLevel(logging.ERROR)
-    
-    logger.info('Started')
-    
-    if args['example_cfg'] :
-        p = os.path.abspath(os.path.normpath(args['example_cfg']))
-        if os.path.exists(os.path.dirname(p)) or os.path.exists(p) :
-            if os.path.exists(p) :
-                logger.info('Example cfg would be overwrited')
-            write_example_cfg(args['example_cfg'], default_config)
-            logger.info('Example cfg created')
-            return 0
-        else :
-            logger.warning('Invalid path for example cfg creation. Directory does not exist')
-            return 1
-    
     if args['threads'] :
         if args['bio2'] :
             if not 'nprocs' in args['bio2_args'] :
@@ -184,11 +35,11 @@ def run():
             else :
                 logger.debug('-openms_args already contains -threads option, iqmma -threads {} is ignored'.format(args['threads']))
     logger.debug(args)
-    
+
     if not args['s1'] :
         logger.critical('At least one file in the argument is needed: -s1 {}'.format(args['s1']))
         raise ValueError('At least one file in the argument is needed: -s1 {}'.format(args['s1']))
-    
+
     mode = None
     if not args['s2'] :
         sample_nums = ['s1']
@@ -198,7 +49,7 @@ def run():
         sample_nums = ['s1', 's2']
         logger.info('mode = diffacto')
         mode = 'diffacto'
-    
+
     for sample_num in sample_nums :
         if args[sample_num] :
             if type(args[sample_num]) is str :
@@ -208,7 +59,7 @@ def run():
             else :
                 logger.critical('invalid {} input'.format(sample_num))
                 return -1
-    
+
 #    print(args['s1'].split())
 
     if mode == 'diffacto' :
@@ -220,7 +71,7 @@ def run():
             raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), args['dif'])
         else :
             args['dif'] = os.path.abspath(os.path.normpath(args['dif']))
-            
+
         if set(args[sample_nums[0]]) & set(args[sample_nums[1]]) :
             logger.critical('Identical files added for both samples (s1 and s2). Statistical test cannot be performed.')
             raise ValueError(errno.ENOENT, os.strerror(errno.ENOENT), set(args[sample_nums[0]]) & set(args[sample_nums[1]]))
@@ -228,13 +79,13 @@ def run():
 #     if not args['scav2dif'] :
 #         logger.warning('path to scav2diffacto.py file is required')
 #         return -1
-    
+
     arg_suff = ['dino', 'bio2', 'openMS']
     suffixes = []
     for suf in arg_suff :
         if args[suf] :
             suffixes.append(suf)
-    
+
     k = len(suffixes)
     if k == 0 :
         logger.critical('At least one feature detector shoud be given!')
@@ -246,7 +97,7 @@ def run():
         logger.info('Second diffacto run applied')
     else :
         logger.info('No diffacto run applied')
-    
+
     samples = []
     samples_dict = {}
     mzML_paths = []
@@ -256,12 +107,12 @@ def run():
             mzML_paths.append(z)
             samples.append(os.path.basename(z).replace('.mzML', ''))
             samples_dict[sample_num].append(os.path.basename(z).replace('.mzML', ''))
-            
+
     if args['min_samples'] == -1 :
         args['min_samples'] = int(len(samples)/2)
     if args['min_samples'] == 0 :
         args['min_samples'] = min([len(samples_dict[x]) for x in sample_nums])
-    
+
     logger.debug('samples_dict = ' + str(samples_dict))
 
     PSMs_full_paths = []
@@ -287,19 +138,19 @@ def run():
                 logger.critical('sample ' + sample + ' PSM file not found')
                 return -1
     logger.debug(PSMs_full_dict)
-    
+
     if not args['outdir'] :
         logger.info('Path to output directory is not specified. Using input files directory instead.')
         args['outdir'] = os.path.dirname(mzML_paths[0])
     else :
         args['outdir'] = os.path.abspath(os.path.normpath(args['outdir']))
         logger.info('Results are stored at {}'.format(args['outdir']))
-    
+
     mzML_dict = {}
     for sample, mzML in zip(samples, mzML_paths) :
         mzML_dict[sample] = mzML
-    
-    if mode != 'feature matching' : 
+
+    if mode != 'feature matching' :
         if args['allowed_pepts'] :
             if os.path.exists(os.path.normpath(args['allowed_pepts'])) :
                 logger.info('Peptides from file {} are allowed for quantitative analysis'.format(os.path.normpath(args['allowed_pepts'])))
@@ -317,10 +168,10 @@ def run():
             else :
                 logger.warning('path to proteins files folder does not exist: {}'.format(os.path.normpath(args['allowed_prots'])))
                 proteins_path = ''
-        else : 
+        else :
             proteins_path = ''
-    
-    paths = {'mzML': mzML_dict, 
+
+    paths = {'mzML': mzML_dict,
              'PSM_full' : PSMs_full_dict,
             }
     if mode != 'feature matching' :
@@ -350,8 +201,8 @@ def run():
     #     logger.critical('Invalid value for setting: -dynamic_fc_threshold %s', args['dynamic_fc_threshold'])
     #     raise ValueError('Invalid value for setting: -dynamic_fc_threshold %s', args['dynamic_fc_threshold'])
 
-        
-    
+
+
     logger.debug('PSMs_full_paths: %s', PSMs_full_paths)
     logger.debug('mzML_paths: %s', mzML_paths)
     logger.debug('out_directory: %s', out_directory)
@@ -417,11 +268,11 @@ def run():
                     logger.info('\n' + 'Not overwriting features ' + ' bio2 ' + sample + '\n')
         else :
             logger.critical('Skipping Biosaur2. Path to Biosaur2 does not exists: {}'.format(args['bio2']))
-            
+
 ### OpenMS
 
 # На выходе создает в feature_path папку OpenMS с файлами *.featureXML и добавляет в папку out_directory/features файлы *sample*_features_openMS.tsv
-    
+
     if args['openMS'] :
         if os.path.exists(os.path.normpath(args['openMS'])) :
             out_path = os.path.join(feature_path, 'openMS')
@@ -438,12 +289,12 @@ def run():
             for path, sample in zip(mzML_paths, samples) :
                 out_path = os.path.join(feature_path, 'openMS', sample + '.featureXML')
                 o = os.path.join(feature_path, sample + '_features_' + 'openMS.tsv')
-                if args['overwrite_features'] == 1 or not os.path.exists(o) : 
+                if args['overwrite_features'] == 1 or not os.path.exists(o) :
                     logger.info('Writing features ' + ' openMS ' + sample)
                     a = featurexml.read(out_path)
 
                     features_list = []
-                    for z in a : 
+                    for z in a :
                         mz = float(z['position'][1]['position'])
                         # rtApex = float(z['position'][0]['position']) / 60
                         rtStart = float(z['convexhull'][0]['pt'][0]['x'])/60
@@ -486,7 +337,7 @@ def run():
                 temp_df = optimized_search_with_isotope_error_(feats, PSM, isotopes_array=args['isotopes'], logger=logger)[0]
                 # temp_df = optimized_search_with_isotope_error_(feats, PSM, mean_rt1=0,sigma_rt1=1e-6,mean_rt2=0,sigma_rt2=1e-6,mean_mz = False,sigma_mz = False,mean_im = False,sigma_im = False, isotopes_array=[0,1,-1,2,-2], logger=logger)[0]
 
-                if args['mbr']:    
+                if args['mbr']:
                     logger.info('Start match-between-runs for features {} {}'.format(sample, suf))
                     temp_df = mbr(feats, temp_df, PSMs_full_paths, PSM_path, logger=logger)
 
@@ -495,15 +346,15 @@ def run():
                 temp_df['min_norm_feature_intensityApex'] = temp_df['feature_intensityApex']/temp_df['feature_intensityApex'].min()
                 temp_df['max_norm_feature_intensityApex'] = temp_df['feature_intensityApex']/temp_df['feature_intensityApex'].max()
                 cols = list(temp_df.columns)
-                
+
                 logger.info(suf + ' features ' + sample + ' DONE')
                 temp_df.to_csv(os.path.join(matching_path, sample + '_' + suf + '.tsv'), sep='\t', columns=cols)
-                logger.info(sample + ' PSMs matched ' + str(temp_df['feature_intensityApex'].notna().sum()) + '/' 
+                logger.info(sample + ' PSMs matched ' + str(temp_df['feature_intensityApex'].notna().sum()) + '/'
                              + str(len(temp_df)) + ' ' + str(round(temp_df['feature_intensityApex'].notna().sum()/len(temp_df)*100, 2)) + '%')
                 logger.info(suf + ' MATCHED')
-                
-        temp_df = None   
-    
+
+        temp_df = None
+
     paths['feats_matched'] = {}
     for sample in samples :
         feats_matched_paths = {}
@@ -518,7 +369,7 @@ def run():
         paths['feats_matched'][sample] = feats_matched_paths
     logger.info('Matching features for PSMs done')
 
-    
+
     ## Подготовка и прогон Диффакто 1
 
     if mode == 'diffacto' :
@@ -541,15 +392,15 @@ def run():
             intens_colomn_name = 'med_norm_feature_intensityApex'
         elif args['norm'] == 0 :
             intens_colomn_name = 'feature_intensityApex'
-        
+
         allowed_prots = set()
-        if paths['proteins'] :    
+        if paths['proteins'] :
             df0 = pd.read_table(paths['proteins'], usecols=['dbname'])
             allowed_prots.update(df0['dbname'])
             logger.info('allowed proteins total: %d', len(allowed_prots))
         else :
             logger.info('allowed proteins total: all')
-        
+
         allowed_peptides = set()
         if paths['peptides'] :
             logger.info('Allowed peptides for quantitation from file: {}'.format(paths['peptides'][key]))
@@ -586,7 +437,7 @@ def run():
             psms_dict = {}
             for sample in samples:
                 logger.debug('Starting %s', sample)
-                if loglevel == 'DEBUG' :
+                if args['logs'].upper() == 'DEBUG' :
                     charge_faims_intensity_path = os.path.join(diffacto_folder, 'charge_faims_intensity')
                     os.makedirs(charge_faims_intensity_path, exist_ok=True)
                     out_path = os.path.join(diffacto_folder, 'charge_faims_intensity', sample+'_'+suf+'.tsv')
@@ -594,8 +445,8 @@ def run():
                     out_path = None
                     charge_faims_intensity_path = None
                 psms_dict[sample] = charge_states_intensity_processing(paths['feats_matched'][sample][suf],
-                                                                        method=args['pept_intens'], 
-                                                                        intens_colomn_name=intens_colomn_name, 
+                                                                        method=args['pept_intens'],
+                                                                        intens_colomn_name=intens_colomn_name,
                                                                         allowed_peptides=allowed_peptides, # set()
                                                                         allowed_pept_modif=allowed_pept_modif,
                                                                         allowed_prots=allowed_prots, # set()
@@ -618,10 +469,10 @@ def run():
                                           write_peptides=True,
                                           str_of_other_args = args['diffacto_args'],
                                           logger=logger
-                                         )  
+                                         )
             logger.info('Done Diffacto run with %s', suf)
             psms_dict = False
-            
+
         if k <= 2 or args['mixed'] != 1 :
             save = True
             if k <= 2 or args['venn'] != 1 :
@@ -633,51 +484,51 @@ def run():
             plot_venn = False
 
         num_changed_prots = generate_users_output(
-            diffacto_out = paths['DiffOut'], 
-            out_folder = out_directory, 
-            plot_venn = plot_venn, 
+            diffacto_out = paths['DiffOut'],
+            out_folder = out_directory,
+            plot_venn = plot_venn,
             pval_threshold = args['pval_threshold'],
             pval_adj=args['pval_adj'],
-            fc_threshold = args['fc_threshold'], 
-            dynamic_fc_threshold = args['dynamic_fc_threshold'], 
-            save = save, 
+            fc_threshold = args['fc_threshold'],
+            dynamic_fc_threshold = args['dynamic_fc_threshold'],
+            save = save,
             logger=logger
         )
-        
+
         if sum(list(num_changed_prots.values())) == 0 :
             logging.warning('No differentially expressed proteins detected in separate diffacto runs')
-        
+
         if args['choice'] == 0 :
             default_order = sorted(suffixes, key= lambda x: num_changed_prots[x], reverse=True)
-        else : 
+        else :
             default_order = False
-        
-        
+
+
         ## Второй прогон диффакто
-        
-        
+
+
         if k >= 2 and args['mixed'] == 1 :
             suf = 'mixed'
             logger.info('Mixing intensities STARTED')
-            
+
             to_diffacto = os.path.join(diffacto_folder, args['outpept'].replace('.txt', '_' + suf + '.txt'))
             a = mix_intensity(paths['DiffPept'],
                               samples_dict,
-                              choice=args['choice'], 
-                              suf_dict={'dino':'D', 'bio2':'B2', 'openMS':'O', 'mixed':'M'}, 
+                              choice=args['choice'],
+                              suf_dict={'dino':'D', 'bio2':'B2', 'openMS':'O', 'mixed':'M'},
                               out_dir= charge_faims_intensity_path,
                               default_order= default_order,
                               to_diffacto= to_diffacto,
-                              logger=logger 
+                              logger=logger
                               )
-            
+
             logger.info('Mixing intensities DONE with exitscore {}'.format(a))
-            
+
             paths['DiffPept'][suf] = to_diffacto
             paths['DiffSampl'][suf] = os.path.join(diffacto_folder, args['outsampl'].replace('.txt', '_' + suf + '.txt'))
             paths['DiffOut'][suf] = os.path.join(diffacto_folder, args['outdiff'].replace('.txt', '_' + suf + '.txt'))
-            
-            logger.info('Diffacto START')        
+
+            logger.info('Diffacto START')
             exitscore = diffacto_call(diffacto_path = args['dif'],
                                       out_path = paths['DiffOut'][suf],
                                       peptide_path = paths['DiffPept'][suf],
@@ -689,7 +540,7 @@ def run():
                                       logger=logger
                                      )
             logger.info('Done Diffacto run with {} with exitscore {}'.format(suf, exitscore))
-            
+
             save = True
             if args['venn'] != 1 :
                 plot_venn = False
@@ -697,22 +548,18 @@ def run():
                 plot_venn = True
 
             num_changed_prots = generate_users_output(
-                diffacto_out = paths['DiffOut'], 
-                out_folder = out_directory, 
-                plot_venn = plot_venn, 
-                pval_threshold = args['pval_threshold'], 
+                diffacto_out = paths['DiffOut'],
+                out_folder = out_directory,
+                plot_venn = plot_venn,
+                pval_threshold = args['pval_threshold'],
                 pval_adj=args['pval_adj'],
-                fc_threshold = args['fc_threshold'], 
-                dynamic_fc_threshold = args['dynamic_fc_threshold'], 
-                save = save, 
+                fc_threshold = args['fc_threshold'],
+                dynamic_fc_threshold = args['dynamic_fc_threshold'],
+                save = save,
                 logger=logger
             )
             logger.info('Numbers of differentially expressed proteins:')
             for suf in suffixes+['mixed'] :
                 logger.info('{}: {}'.format(suf, num_changed_prots[suf]))
-                
+
             logger.info('IQMMA finished')
-
-if __name__ == '__main__':
-    run()
-

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,7 @@
 '''
 setup.py file for iqmma
 '''
-import os
-from setuptools import setup, find_packages, Extension
+from setuptools import setup
 
 version = open('VERSION').readline().strip()
 
@@ -27,5 +26,5 @@ setup(
     license              = 'License :: OSI Approved :: Apache Software License',
     packages         = ['iqmma', ],
     package_data     = {'iqmma': ['default.ini', 'utils.ini']},
-    entry_points         = {'console_scripts': ['iqmma = iqmma.iqmma:run',]},
+    entry_points         = {'console_scripts': ['iqmma = iqmma.cli:run',]},
     )


### PR DESCRIPTION
This PR splits the `run()` function into two, with minimal changes: one parses command-line arguments while the other does the actual processing. This allows calling `process_files` from third-party code. 