### PR TITLE
Unpin numpy version but use diffacto with numpy patch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 pyteomics
 matplotlib
 scipy
-numpy==1.23.1
+numpy
 pandas
 venn
 lxml
 biosaur2
-diffacto
+diffacto @ git+https://github.com/levitsky/diffacto.git@fix/dtype


### PR DESCRIPTION
With this PR, IQMMA can be installed with any recent NumPy version. Instead, Diffacto gets installed from a patched version from my fork.
Since Diffacto is not actively updated now, it's unclear if my patch will get merged. On the upside, my version will not likely become outdated any time soon.